### PR TITLE
Implement search and new series catalog for Latanime

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -4,7 +4,7 @@ const cheerio = require("cheerio");
 
 const manifest = {
     "id": "org.latanime.stremio",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "name": "Latanime",
     "description": "Stremio addon for latanime.org",
     "icon": "https://latanime.org/public/img/logito.png",
@@ -19,6 +19,11 @@ const manifest = {
                 { "name": "search", "isRequired": false },
                 { "name": "skip", "isRequired": false }
             ]
+        },
+        {
+            "type": "series",
+            "id": "latanime-new",
+            "name": "Nuevas Series"
         }
     ],
     "idPrefixes": ["latanime-"]
@@ -29,37 +34,73 @@ const builder = new addonBuilder(manifest);
 const LATANIME_URL = "https://latanime.org";
 const ITEMS_PER_PAGE = 28; // Estimate based on typical grid
 
+const headers = {
+    'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/119.0.0.0 Safari/537.36'
+};
+
 builder.defineCatalogHandler(async ({type, id, extra}) => {
     console.log("request for catalog: " + type + " " + id);
     
-    let page = 1;
-    if (extra && extra.skip) {
-        page = Math.floor(extra.skip / ITEMS_PER_PAGE) + 1;
+    let url;
+    if (extra && extra.search) {
+        url = `${LATANIME_URL}/buscar?q=${encodeURIComponent(extra.search)}`;
+    } else if (id === 'latanime-new') {
+        url = LATANIME_URL;
+    } else {
+        let page = 1;
+        if (extra && extra.skip) {
+            page = Math.floor(extra.skip / ITEMS_PER_PAGE) + 1;
+        }
+        url = `${LATANIME_URL}/animes?page=${page}`;
     }
     
-    const url = `${LATANIME_URL}/animes?page=${page}`;
-    
     try {
-        const response = await axios.get(url);
+        const response = await axios.get(url, { headers });
         const $ = cheerio.load(response.data);
         const metas = [];
 
-        $('div[class^="col-"] a').each((i, el) => {
-            const href = $(el).attr('href');
-            if (href && href.includes('/anime/')) {
-                const title = $(el).find('h3').text().trim();
-                const poster = $(el).find('img').attr('data-src') || $(el).find('img').attr('src');
-                const animeId = href.split('/').pop();
-                if (animeId) {
-                    metas.push({
-                        id: `latanime-${animeId}`,
-                        type: 'series',
-                        name: title,
-                        poster: poster,
-                    });
+        if (id === 'latanime-new' && !extra?.search) {
+             // Homepage "Series recientes" parsing
+             const section = $('h2:contains("Series recientes")').next('ul');
+             section.find('li article a').each((i, el) => {
+                 const href = $(el).attr('href');
+                 if (href && href.includes('/anime/')) {
+                     const title = $(el).find('h3').text().trim();
+                     const img = $(el).find('img');
+                     const poster = img.attr('data-src') || img.attr('src');
+                     const animeId = href.split('/').pop();
+
+                     if (animeId) {
+                         metas.push({
+                             id: `latanime-${animeId}`,
+                             type: 'series',
+                             name: title,
+                             poster: poster,
+                         });
+                     }
+                 }
+             });
+
+        } else {
+            // Standard catalog and search parsing
+            $('div[class^="col-"] a').each((i, el) => {
+                const href = $(el).attr('href');
+                if (href && href.includes('/anime/')) {
+                    const title = $(el).find('h3').text().trim();
+                    const img = $(el).find('img');
+                    const poster = img.attr('data-src') || img.attr('src');
+                    const animeId = href.split('/').pop();
+                    if (animeId) {
+                        metas.push({
+                            id: `latanime-${animeId}`,
+                            type: 'series',
+                            name: title,
+                            poster: poster,
+                        });
+                    }
                 }
-            }
-        });
+            });
+        }
 
         return Promise.resolve({ metas: metas });
     } catch (error) {
@@ -74,7 +115,7 @@ builder.defineMetaHandler(async ({type, id}) => {
     const animeId = id.replace('latanime-', '');
     const url = `${LATANIME_URL}/anime/${animeId}`;
     try {
-        const response = await axios.get(url);
+        const response = await axios.get(url, { headers });
         const $ = cheerio.load(response.data);
         const title = $('h2').text().trim();
         const poster = $('.serieimgficha img').attr('src');
@@ -87,27 +128,19 @@ builder.defineMetaHandler(async ({type, id}) => {
                 const episodeTitleRaw = $(el).text().trim().replace(/\s\s+/g, ' ');
                 const episodeId = href.split('/').pop();
                 
-                // Parsing Season and Episode
-                // Default to Season 1
                 let season = 1;
-                let episode = videos.length + 1; // Default fallback
+                let episode = videos.length + 1;
 
-                // Try to extract numbers from title
-                // Example titles: "Episodio 1", "Season 2 Episode 3"
-                // Note: latanime titles are often just "Episodio X" or the anime title + "Episodio X"
                 const epMatch = episodeTitleRaw.match(/(?:episodio|capitulo)\s*(\d+)/i);
                 if (epMatch) {
                     episode = parseInt(epMatch[1], 10);
                 } else {
-                    // Fallback: try to extract last number
                      const numMatch = episodeTitleRaw.match(/(\d+)$/);
                      if (numMatch) {
                          episode = parseInt(numMatch[1], 10);
                      }
                 }
 
-                // Try to find season in the Anime Title or Episode Title (rare in this site, usually S1)
-                // But if the anime slug contains "temporada-2", we can infer season 2
                 const seasonMatch = animeId.match(/(?:temporada|season)-(\d+)/i);
                 if (seasonMatch) {
                     season = parseInt(seasonMatch[1], 10);
@@ -131,11 +164,7 @@ builder.defineMetaHandler(async ({type, id}) => {
             name: title,
             poster: poster,
             description: description,
-            videos: videos.reverse() // Usually listed newest first, Stremio likes predictable order but we just send them all.
-                                     // Actually, reversing might make them 1..N if they were N..1
-                                     // Let's check index. If we rely on parsing, order doesn't matter for numbering, 
-                                     // but for display it should be 1 first.
-                                     // .reverse() is good if site lists newest first.
+            videos: videos.reverse()
         };
         return Promise.resolve({ meta: meta });
     } catch (error) {
@@ -149,12 +178,11 @@ builder.defineStreamHandler(async ({type, id}) => {
     const episodeId = id.replace('latanime-', '');
     const url = `${LATANIME_URL}/ver/${episodeId}`;
     try {
-        const response = await axios.get(url);
+        const response = await axios.get(url, { headers });
         const $ = cheerio.load(response.data);
 
         const streams = [];
-        // Updated selector to 'a[data-player]' based on inspection
-        // Also kept 'button' just in case they mix them, using comma
+
         $('a[data-player], button[data-player]').each((i, el) => {
             const encodedPlayerUrl = $(el).attr('data-player');
             const providerName = $(el).text().trim();
@@ -162,19 +190,11 @@ builder.defineStreamHandler(async ({type, id}) => {
                 try {
                     const decodedUrl = Buffer.from(encodedPlayerUrl, 'base64').toString('utf8');
                     if (decodedUrl) {
-                        // Check if it's a direct file or an embed
-                        // If it's an embed, Stremio might not play it directly unless we resolve it.
-                        // For now, we pass it as 'externalUrl' if it looks like a page, 
-                        // or 'url' if it looks like a video file.
-                        // Most of these are embeds (filemoon, etc).
-                        // Stremio generally requires a direct stream or a supported embed.
-                        // We will just return it as 'url' for now, as some players handle standard embeds.
-                        
                         streams.push({
                             url: decodedUrl,
                             title: providerName,
                             behaviorHints: {
-                                notWebReady: true // likely requires headers or specific player
+                                notWebReady: true
                             }
                         });
                     }
@@ -183,15 +203,6 @@ builder.defineStreamHandler(async ({type, id}) => {
                 }
             }
         });
-        
-        // Also look for download links which are often direct video files
-        // Selectors based on inspection: they seem to be just links, but maybe we can find them?
-        // The inspection showed "Pixeldrain", "Mega" buttons.
-        // They were <a href="...">...</a>.
-        // We can scrape those too if they are simple links.
-        // Based on curl:
-        // <a href="https://pixeldrain.com/u/..." ...>Pixeldrain</a>
-        // We can add a selector for these specific known hosts.
         
         const downloadSelectors = [
             'a[href*="pixeldrain.com"]',

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,18 @@
       "dependencies": {
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",
+        "node-cache": "^5.1.2",
+        "scrapingbee": "^1.7.6",
         "stremio-addon-sdk": "^1.6.10"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.4.tgz",
+      "integrity": "sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/accepts": {
@@ -79,6 +90,16 @@
         "proxy-from-env": "^1.1.0"
       }
     },
+    "node_modules/axios-retry": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.9.1.tgz",
+      "integrity": "sha512-8PJDLJv7qTTMMwdnbMvrLYuvB47M81wRtxQmEdV5w4rgbTXTt+vtPkXwajOfOdSyv/wZICJOC+/UhXH4aQ/R+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.15.4",
+        "is-retry-allowed": "^2.2.0"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.3",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
@@ -145,6 +166,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/chalk": {
@@ -226,6 +259,15 @@
       "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.1.tgz",
       "integrity": "sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==",
       "license": "ISC"
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color-convert": {
       "version": "1.9.3",
@@ -338,6 +380,18 @@
       "license": "MIT",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/decamelize": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-4.0.0.tgz",
+      "integrity": "sha512-9iE1PgSik9HeIIw2JO94IidnE3eBoQrFJ3w7sFuzSX4DpmZ3v5sZpUiV5Swcf6mQEF+Y0ru8Neo+p+nyh2J+hQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/delayed-stream": {
@@ -648,6 +702,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/flat": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/flat/-/flat-5.0.2.tgz",
+      "integrity": "sha512-b6suED+5/3rTpUBdG1gupIl8MPFCAMA0QXwmljLhvCUKcUvdE4gWky9zpuGCcXHOsz4J9wPGNWq6OKpmIzz3hQ==",
+      "license": "BSD-3-Clause",
+      "bin": {
+        "flat": "cli.js"
+      }
+    },
     "node_modules/follow-redirects": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -915,6 +978,27 @@
         "node": ">=4"
       }
     },
+    "node_modules/is-plain-obj": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.1.0.tgz",
+      "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-retry-allowed": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
+      "integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-1.1.0.tgz",
@@ -1048,6 +1132,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-cache": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/node-cache/-/node-cache-5.1.2.tgz",
+      "integrity": "sha512-t1QzWwnk4sjLWaQAS8CHgOJ+RAfmHpxFWmc36IWTiWHQfs0w5JDMBS1b1ZxQteo0vVVuWJvIUKHDkkeK7vIGCg==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "2.x"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
       }
     },
     "node_modules/node-fetch": {
@@ -1359,6 +1455,18 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/scrapingbee": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/scrapingbee/-/scrapingbee-1.7.6.tgz",
+      "integrity": "sha512-k+HDJcvUQ0ZMob1FuGR4IurPGpQRJBhcYBzyjb7MyXdVIJpnEOexj6IcOhmWuuah6NHGo24BJdvQfFxbPa5WGA==",
+      "license": "ISC",
+      "dependencies": {
+        "axios": "^1.7",
+        "axios-retry": "^3.4.0",
+        "scrapingbee": "^1.1.0",
+        "yargs-unparser": "^2.0.0"
+      }
     },
     "node_modules/semver": {
       "version": "5.7.2",
@@ -1738,6 +1846,21 @@
       "dependencies": {
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/yargs-unparser": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-2.0.0.tgz",
+      "integrity": "sha512-7pRTIA9Qc1caZ0bZ6RYRGbHJthJWuakf+WmHK0rVeLkNrrGhfoabBNdue6kdINI6r4if7ocq9aD/n7xwKOdzOA==",
+      "license": "MIT",
+      "dependencies": {
+        "camelcase": "^6.0.0",
+        "decamelize": "^4.0.0",
+        "flat": "^5.0.2",
+        "is-plain-obj": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,8 @@
   "dependencies": {
     "axios": "^1.7.2",
     "cheerio": "^1.0.0-rc.12",
+    "node-cache": "^5.1.2",
+    "scrapingbee": "^1.7.6",
     "stremio-addon-sdk": "^1.6.10"
   }
 }


### PR DESCRIPTION
- Added `latanime-new` catalog to manifest and handler to scrape "Series recientes" from homepage.
- Implemented search support in catalog handler using `/buscar?q=` endpoint.
- Updated `manifest` version to 1.0.2.
- Added `User-Agent` header to axios requests to avoid blocking.
- Ensured stream handler includes download selectors for direct file links.