### PR TITLE
fix: Refine stream handler selector to exclude images

### DIFF
--- a/addon.js
+++ b/addon.js
@@ -279,7 +279,7 @@ builder.defineStreamHandler(async ({type, id}) => {
         const playerAttributes = ['data-player', 'data-src', 'data-stream', 'data-video', 'data-url'];
         
         playerAttributes.forEach(attr => {
-            $(`[${attr}]`).each((i, el) => {
+            $(`*:not(img)[${attr}]`).each((i, el) => {
                 const encodedPlayerUrl = $(el).attr(attr);
                 let providerName = $(el).text().trim() || $(el).attr('title') || $(el).attr('data-title');
                 


### PR DESCRIPTION
The stream handler was using an overly broad selector (`[data-src]`) that inadvertently captured image URLs from lazy-loaded thumbnails in the "recommended" section of episode pages.

This polluted the stream list with invalid data, causing the metadata mismatch and playback failures reported by the user.

The selector has been updated to `*:not(img)[data-src]` to specifically exclude image tags from the query. This ensures only legitimate video player data is scraped, resolving the bug and restoring correct addon functionality.