### PR TITLE
fix: Add postinstall script for Playwright installation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "latanime-addon",
       "version": "1.0.0",
+      "hasInstallScript": true,
       "dependencies": {
         "axios": "^1.7.2",
         "cheerio": "^1.0.0-rc.12",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Provides streams from latanime.org",
   "main": "server.js",
   "scripts": {
-    "start": "concurrently \"node server.js\" \"node bridge-server.js\""
+    "start": "concurrently \"node server.js\" \"node bridge-server.js\"",
+    "postinstall": "npx playwright install --with-deps"
   },
   "dependencies": {
     "axios": "^1.7.2",


### PR DESCRIPTION
Adds a `postinstall` script to `package.json` to automatically run `npx playwright install --with-deps`.

This is a critical fix for deployment environments like Render, where the build process needs to explicitly install the Playwright browsers and their dependencies. Without this script, the bridge server would fail to launch.