### PR TITLE
fix: Re-add Dockerfile for deployment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+# Use the official Playwright image which comes with browsers and dependencies installed
+FROM mcr.microsoft.com/playwright:v1.45.0-jammy
+
+# Set the working directory in the container
+WORKDIR /app
+
+# Copy package.json and package-lock.json to leverage Docker cache
+COPY package*.json ./
+
+# Install dependencies
+RUN npm install
+
+# Copy the rest of the application files
+COPY . .
+
+# Expose the port the app runs on
+EXPOSE 10000
+
+# Command to run the application
+CMD ["npm", "start"]


### PR DESCRIPTION
The previous commit failed to build because the `Dockerfile` was missing. This commit re-adds the `Dockerfile` with the correct Playwright image version (`v1.45.0-jammy`) to ensure the deployment environment can build and run the application successfully.

This also includes the original fix for the Cinemeta API User-Agent.