### PR TITLE
fix: Ensure Playwright browsers are installed in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,8 @@ COPY package*.json ./
 
 # Install dependencies
 RUN npm install
+# Install Playwright browsers and dependencies
+RUN npx playwright install --with-deps
 
 # Copy the rest of the application files
 COPY . .


### PR DESCRIPTION
Adds `RUN npx playwright install --with-deps` to the Dockerfile.

This command explicitly installs the Chromium browser and its necessary dependencies during the Docker build process. This resolves a fatal error where the Playwright executable was not found in the Render deployment environment, causing the bridge service to crash on startup.

This change ensures the application is fully self-contained and deployable on Render without manual intervention.