### PR TITLE
Fix player stream extraction: decode data-player as base64 provider URL (v4.4.1)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ async function cacheSet(key: string, data: unknown, ttlSec: number, kv: KVNamesp
 
 const MANIFEST = {
   id: ADDON_ID,
-  version: "4.4.0",
+  version: "4.4.1",
   name: "Latanime",
   description: "Anime Latino y Castellano desde latanime.org — con Browser Rendering",
   logo: "https://latanime.org/public/img/logito.png",
@@ -394,46 +394,32 @@ async function getStreams(rawId: string, env: Env, request: Request) {
   const embedUrls: { url: string; name: string }[] = [];
   const seen = new Set<string>();
 
-  // data-key = base64 of the base URL prefix
-  // data-player = path suffix to append (yourupload is the exception: full base64)
+  // The site has used two encodings for data-player:
+  //   • full base64 of the provider URL (current as of 2026-07, all players)
+  //   • literal path suffix appended to the data-key base64 prefix
+  // Decode-first handles both: a literal suffix never base64-decodes to a URL,
+  // and concatenating the current prefix ("…/reproductor?url=") only yields
+  // latanime's JS wrapper page, whose provider host the extractors below
+  // can never see.
   const keyM = html.match(/data-key="([A-Za-z0-9+/=]+)"/);
   const baseUrl = keyM ? (() => { try { return atob(keyM[1]); } catch { return ""; } })() : "";
 
   for (const m of html.matchAll(/<a[^>]+data-player="([^"]+)"[^>]*>([\s\S]*?)<\/a>/gi)) {
-    const suffix = m[1].trim();
-    const name   = m[2].replace(/<[^>]+>/g, "").trim() || "Player";
-    if (seen.has(suffix)) continue;
-    seen.add(suffix);
+    const raw  = m[1].trim();
+    const name = m[2].replace(/<[^>]+>/g, "").trim() || "Player";
+    if (seen.has(raw)) continue;
+    seen.add(raw);
 
     let embedUrl = "";
-    const nameLower = name.toLowerCase();
-
-    if (nameLower.includes("yourupload")) {
-      // yourupload uses full base64 in data-player
-      try { embedUrl = atob(suffix); } catch { continue; }
-    } else {
-      // everyone else: base64_base + suffix
-      embedUrl = baseUrl + suffix;
-    }
+    try {
+      const decoded = atob(raw);
+      if (decoded.startsWith("http") || decoded.startsWith("//")) embedUrl = decoded;
+    } catch { }
+    if (!embedUrl && baseUrl) embedUrl = baseUrl + raw;
 
     if (embedUrl.startsWith("//")) embedUrl = `https:${embedUrl}`;
     if (!embedUrl.startsWith("http")) continue;
     embedUrls.push({ url: embedUrl, name });
-  }
-
-  // Fallback: old-style full base64 in data-player (in case site changes back)
-  if (embedUrls.length === 0) {
-    for (const m of html.matchAll(/<a[^>]+data-player="([A-Za-z0-9+/=]{20,})"[^>]*>([\s\S]*?)<\/a>/gi)) {
-      const b64  = m[1];
-      const name = m[2].replace(/<[^>]+>/g, "").trim() || "Player";
-      if (seen.has(b64)) continue;
-      seen.add(b64);
-      let embedUrl = "";
-      try { embedUrl = atob(b64); } catch { continue; }
-      if (embedUrl.startsWith("//")) embedUrl = `https:${embedUrl}`;
-      if (!embedUrl.startsWith("http")) continue;
-      embedUrls.push({ url: embedUrl, name });
-    }
   }
 
   // Scrape download mirror links directly from episode page


### PR DESCRIPTION
## Summary

Live inspection of latanime.org (2026-07-04) found the player markup has drifted from what `src/index.ts` assumes — exactly the drift class PR #67's `inspect-site.mjs` script flags (its ⚠ heuristic fired on all 8 players of a current episode).

**What changed on the site:** every `data-player` attribute now holds the **full base64-encoded provider URL** (e.g. decoding to `https://savefiles.com/e/ga0zii1om7n5`), while `data-key` decodes to the site's own wrapper prefix `https://latanime.org/reproductor?url=`.

**Why that broke streams:** the addon concatenated `atob(data-key) + data-player`, producing `latanime.org/reproductor?url=<b64>` wrapper URLs. That page is a tiny client-side JS shim that builds an iframe at runtime, so the provider hostname never appears in the URL — none of the host-matching extractors (savefiles HLS, pixeldrain, etc.) could fire. The existing old-scheme fallback never ran because it only triggers when the embed list is empty, and the wrapper URLs looked valid enough to fill it.

## Fix

Decode-first: try `atob(data-player)` and use it when it decodes to a URL; fall back to `prefix + suffix` otherwise. This handles both encodings the site has flip-flopped between and subsumes the previous yourupload special case (which was already full-base64). Removes the now-dead empty-list fallback block. Net −14 lines.

## Verification

- `tsc --noEmit` clean.
- Compiled the worker and invoked `/stream/series/latanime:…:1.json` in Node against the live site, before vs. after:
  - **Before (main):** 10 streams, **8 of them dead `reproductor?url=` wrappers** — only the download-mirror-scraped savefiles HLS streams worked.
  - **After:** 11 streams, **0 wrappers** — direct HLS/MP4 extraction restored for savefiles (1080p/480p), hexload, and mp4upload, plus clean provider embed URLs for dsvplay, byse, mega, mixdrop, voe.
- Also live-verified during inspection: catalog/search/meta/episode parsing assumptions all still hold; `POST /buscar_ajax` returned 403 from this datacenter IP but the existing `GET /buscar` fallback works (8 results for "naruto"), so no search change needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QicBinyzgWAwBhQd3i6G9U

---
_Generated by [Claude Code](https://claude.ai/code/session_01QicBinyzgWAwBhQd3i6G9U)_