### PR TITLE
Align streams with current Stremio protocol + fix 404 logo/poster paths (v4.4.3)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -54,10 +54,10 @@ async function cacheSet(key: string, data: unknown, ttlSec: number, kv: KVNamesp
 
 const MANIFEST = {
   id: ADDON_ID,
-  version: "4.4.2",
+  version: "4.4.3",
   name: "Latanime",
   description: "Anime Latino y Castellano desde latanime.org — con Browser Rendering",
-  logo: "https://latanime.org/public/img/logito.png",
+  logo: "https://latanime.org/img/logito.png",
   resources: ["catalog", "meta", "stream"],
   types: ["series"],
   catalogs: [
@@ -195,7 +195,7 @@ function parseAnimeCards(html: string) {
 }
 
 function toMetaPreview(c: { id: string; name: string; poster: string }) {
-  return { id: c.id, type: "series", name: c.name, poster: c.poster || `${BASE_URL}/public/img/anime.png`, posterShape: "poster" };
+  return { id: c.id, type: "series", name: c.name, poster: c.poster || `${BASE_URL}/img/anime.png`, posterShape: "poster" };
 }
 
 async function searchAnimes(query: string, env?: Env) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,7 +54,7 @@ async function cacheSet(key: string, data: unknown, ttlSec: number, kv: KVNamesp
 
 const MANIFEST = {
   id: ADDON_ID,
-  version: "4.4.1",
+  version: "4.4.2",
   name: "Latanime",
   description: "Anime Latino y Castellano desde latanime.org — con Browser Rendering",
   logo: "https://latanime.org/public/img/logito.png",
@@ -532,7 +532,20 @@ async function getStreams(rawId: string, env: Env, request: Request) {
       }
       if (!streams.some(s => s.url === finalUrl)) {
         const isMediafire = name.includes("MediaFire");
-        const entry = { url: finalUrl, title: `▶ ${name} — Latino`, behaviorHints: { notWebReady: isHls } };
+        const label = `▶ ${name} — Latino`;
+        const entry = {
+          url: finalUrl,
+          name: `Latanime ${isHls ? "HLS" : "MP4"}`,
+          title: label,
+          description: label,
+          behaviorHints: {
+            notWebReady: isHls,
+            // filename drives format detection in Stremio's local streaming
+            // server — the proxied URLs carry no usable extension themselves
+            filename: `${slug}-e${epNum}.${isHls ? "m3u8" : "mp4"}`,
+            bingeGroup: `latanime-${name}`,
+          },
+        };
         if (isMediafire) streams.unshift(entry); else streams.push(entry);
       }
       extractedNames.add(name);
@@ -542,7 +555,14 @@ async function getStreams(rawId: string, env: Env, request: Request) {
         if (m3u8_480 !== streamUrl) {
           const url480 = hlsProxyUrl(m3u8_480, "https://streamhls.to/");
           if (!streams.some(s => s.url === url480)) {
-            streams.push({ url: url480, title: `▶ ${name} 480p — Latino`, behaviorHints: { notWebReady: true } });
+            const label480 = `▶ ${name} 480p — Latino`;
+            streams.push({
+              url: url480,
+              name: "Latanime HLS 480p",
+              title: label480,
+              description: label480,
+              behaviorHints: { notWebReady: true, filename: `${slug}-e${epNum}-480p.m3u8`, bingeGroup: `latanime-${name}-480p` },
+            });
           }
         }
       }
@@ -551,7 +571,14 @@ async function getStreams(rawId: string, env: Env, request: Request) {
 
   for (const embed of embedUrls) {
     if (!extractedNames.has(embed.name)) {
-      streams.push({ url: embed.url, title: `🌐 ${embed.name} — Latino`, behaviorHints: { notWebReady: true } });
+      const label = `🌐 ${embed.name} — Latino`;
+      streams.push({
+        url: embed.url,
+        name: "Latanime 🌐",
+        title: label,
+        description: label,
+        behaviorHints: { notWebReady: true, bingeGroup: `latanime-${embed.name}` },
+      });
     }
   }
 
@@ -562,7 +589,13 @@ async function getStreams(rawId: string, env: Env, request: Request) {
     if (idM) {
       const pdUrl = `https://pixeldrain.com/api/file/${idM[1]}`;
       if (!streams.some(s => s.url === pdUrl)) {
-        streams.unshift({ url: pdUrl, title: "▶ Pixeldrain — Latino", behaviorHints: { notWebReady: true } });
+        streams.unshift({
+          url: pdUrl,
+          name: "Latanime MP4",
+          title: "▶ Pixeldrain — Latino",
+          description: "▶ Pixeldrain — Latino",
+          behaviorHints: { notWebReady: true, filename: `${slug}-e${epNum}.mp4`, bingeGroup: "latanime-pixeldrain" },
+        });
       }
     }
   }


### PR DESCRIPTION
## Summary

Follow-up to #68, prompted by checking the addon's responses against the current [stremio-addon-sdk stream spec](https://github.com/Stremio/stremio-addon-sdk/blob/master/docs/api/responses/stream.md). The manifest is fully spec-valid, but the stream objects were behind the protocol in three ways that affect how modern Stremio clients parse and play them:

1. **No `behaviorHints.filename`** — the spec calls it "highly recommended to set it when using `stream.url`". Stremio's player routes streams through its local HTTP server and detects the container format from the filename/extension, but the worker's `/proxy/m3u8?url=…` URLs carry no usable extension, so format detection was left to content-type guesswork.
2. **Only the deprecated `title` field** — the spec deprecates `title` in favor of `description`.
3. **No `name`** — the bold stream label rendered as blank/addon-fallback in the stream list.

Additionally, latanime.org dropped the `/public` prefix from its static assets, so the manifest logo (`/public/img/logito.png`) and the catalog fallback poster (`/public/img/anime.png`) both 404'd. The site is https-only (`http://` 301s to `https://`), so this was purely the moved path.

## Changes

- Every stream now sets `name` (`Latanime HLS` / `Latanime MP4` / `Latanime HLS 480p` / `Latanime 🌐`)
- `description` added alongside `title` (kept for backwards compat with older clients)
- `behaviorHints.filename` with a real `.m3u8`/`.mp4` extension on every direct-url stream (proxied HLS, MediaFire/mp4upload/hexload MP4, Pixeldrain)
- `behaviorHints.bingeGroup` per provider/quality so next-episode auto-select sticks with the same source
- Manifest logo → `https://latanime.org/img/logito.png`, fallback poster → `https://latanime.org/img/anime.png` (both verified 200 `image/png` live)
- Version bumped to 4.4.3

No changes to extraction logic, proxying, or caching.

## Verification

- `tsc --noEmit` clean.
- Compiled worker invoked live against a current episode: 11 streams returned, all carrying `name` + `description`, with `filename` hints on every proxied/direct URL and `bingeGroup` everywhere. Example first stream:

```json
{
  "url": "https://…/proxy/m3u8?url=…master.m3u8…",
  "name": "Latanime HLS",
  "title": "▶ savefiles 1080p — Latino",
  "description": "▶ savefiles 1080p — Latino",
  "behaviorHints": {
    "notWebReady": true,
    "filename": "rezero-kara-hajimeru-isekai-seikatsu-s4-latino-e1.m3u8",
    "bingeGroup": "latanime-savefiles 1080p"
  }
}
```

- Old asset paths confirmed 404, new `/img/` paths confirmed 200 via live probes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QicBinyzgWAwBhQd3i6G9U